### PR TITLE
fix: use countryOrder instead of preferredCountries for intl-tel-input v25

### DIFF
--- a/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
+++ b/projects/ngxsmk-tel-input/src/lib/ngxsmk-tel-input.component.ts
@@ -68,7 +68,7 @@ type IntlTelInstance = {
  */
 interface IntlTelInputConfig {
   initialCountry: string;
-  preferredCountries: string[];
+  countryOrder: string[];
   onlyCountries?: string[];
   nationalMode: boolean;
   allowDropdown: boolean;
@@ -799,7 +799,7 @@ export class NgxsmkTelInputComponent implements AfterViewInit, OnChanges, OnDest
 
     const config: IntlTelInputConfig = {
       initialCountry: initialCountry === 'auto' ? 'auto' : (initialCountry?.toLowerCase() || 'us'),
-      preferredCountries: (preferredCountries ?? []).map(c => c.toLowerCase()),
+      countryOrder: (preferredCountries ?? []).map(c => c.toLowerCase()),
       onlyCountries: (onlyCountries ?? []).map(c => c.toLowerCase()),
       nationalMode: true,
       allowDropdown,


### PR DESCRIPTION
## Problem

`intl-tel-input` v25 renamed the `preferredCountries` option to `countryOrder`. As a result, the preferred countries are not displayed at the top of the dropdown list when using `ngxsmk-tel-input`.

## Solution

Updated the config object passed to `intl-tel-input` to use `countryOrder` instead of `preferredCountries`.

## Changes

- Updated `IntlTelInputConfig` interface to use `countryOrder: string[]`
- Changed property name in the config object passed to `intlTelInput()`

## Testing

Tested locally with Angular 21 application - preferred countries now correctly appear at the top of the dropdown.